### PR TITLE
Stray 0.7 deprecation

### DIFF
--- a/src/Sparse_matrixfunctions.jl
+++ b/src/Sparse_matrixfunctions.jl
@@ -1,7 +1,7 @@
 
 # Functions for sparse array view sums - from https://discourse.julialang.org/t/slow-arithmetic-on-views-of-sparse-matrices/3644
 
-rowsum(x) = sum(x,2)
+rowsum(x) = sum(x,dims=2)
 rowsum(x::SubArray{T,2,P}) where {T,P<:SparseMatrixCSC} = (x.parent * sparse(x.indexes[2],ones(Int,length(x.indexes[2])), ones(Int,length(x.indexes[2])), size(x.parent,2),1))[x.indexes[1]]
 colsum(x) = sum(x,dims=1)
 colsum(x::SubArray{T,2,P}) where {T,P<:SparseMatrixCSC} = (sparse(ones(Int,length(x.indexes[1])), x.indexes[1], ones(Int,length(x.indexes[1])),1,size(x.parent,1))*x.parent)[x.indexes[2]]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ amph = Assemblage(amphdat[4:end], amphdat[1:3], sitecolumns = false)
 @test nspecies(amph) == 73
 @test noccurring(amph) == 73
 @test occurring(amph, 718) == [15]
+@test occupancy(amph)[1] == 353
 
 # views
 va = view(amph, species = 1:10)


### PR DESCRIPTION
While upgrading Microbiome, I ran into this warning in my tests:

```
┌ Warning: `sum(a::AbstractArray, dims)` is deprecated, use `sum(a, dims=dims)` instead.
│   caller = rowsum(::SparseArrays.SparseMatrixCSC{Bool,Int64}) at Sparse_matrixfunctions.jl:4
└ @ SpatialEcology ~/.julia/dev/SpatialEcology/src/Sparse_matrixfunctions.jl:4
```

This PR adds a test for the `occupancy()` function which was calling `sum()` with deprecated syntax, and fixes that function.