### PR TITLE
Some compat stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ os:
 julia:
   - 1.3
   - 1.4
+  - 1.5
   - nightly
 
 notifications:

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-DataFrames = "0.20"
+DataFrames = "0.20, 0.21"
 DataFramesMeta = "0.5"
 Distances = "0.8, 0.9"
 EcoBase = "0.1.1"
@@ -28,7 +28,7 @@ RandomBooleanMatrices = "0.1"
 RandomNumbers = "1.4"
 RecipesBase = "0.7, 0.8, 1.0"
 StatsBase = "0.32, 0.33"
-julia = "1.2, 1.3, 1.4"
+julia = "1.2"
 
 [extras]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-DataFrames = "0.20, 0.21"
+DataFrames = "0.21"
 DataFramesMeta = "0.5"
 Distances = "0.8, 0.9"
 EcoBase = "0.1.1"

--- a/src/ComMatrix.jl
+++ b/src/ComMatrix.jl
@@ -101,9 +101,9 @@ function getindex(site::S, inds) where S<:SELocations
 end
 
 function getindex(com::SEAssemblage, ind::Symbol)
-    if ind in names(com.site.sitestats)
+    if ind in propertynames(com.site.sitestats)
         return com.site.sitestats[:,ind]
-    elseif ind in names(com.occ.traits)
+    elseif ind in propertynames(com.occ.traits)
         return com.occ.traits[:,ind]
     else
         error("No such name in traits or sitestats")
@@ -113,9 +113,9 @@ end
 getindex(com::SEAssemblage, ::Colon, ind::Symbol) = getindex(com, ind)
 
 function getindex(com::SEAssemblage, ::typeof(!), ind::Symbol)
-    if ind in names(com.site.sitestats)
+    if ind in propertynames(com.site.sitestats)
         return com.site.sitestats[!,ind]
-    elseif ind in names(com.occ.traits)
+    elseif ind in propertynames(com.occ.traits)
         return com.occ.traits[!,ind]
     else
         error("No such name in traits or sitestats")

--- a/src/Constructors.jl
+++ b/src/Constructors.jl
@@ -83,10 +83,10 @@ function ComMatrix(occ::DataFrames.DataFrame; sitecolumns = true)
     if eltypet(occ[!,1]) <: AbstractString
         species = string.(occ[:,1])
         occ = occ[!,2:end]
-        sites = string.(collect(names(occ)))
+        sites = names(occ)
     else
         species = string.(1:DataFrames.nrow(occ))
-        sites = string.(collect(names(occ)))
+        sites = names(occ)
     end
 
     try

--- a/src/GetandSetdata.jl
+++ b/src/GetandSetdata.jl
@@ -36,7 +36,7 @@ function addtraits!(asm::Assemblage, newtraits::DataFrames.DataFrame, species::S
         max(dif/left, dif/right) < tolerance && error("Aborting join, as fit was smaller than the tolerance of $tolerance . To perform the join decrease the tolerance value")
     end
 
-    nm = names(newtraits)
+    nm = propertynames(newtraits)
     rename!(newtraits, species => :name)
     asm.occ.traits = join(asm.occ.traits, newtraits, kind = :left, on = :name, makeunique = makeunique)
     names!(newtraits, nm)
@@ -60,7 +60,7 @@ function addsitestats!(asm::Assemblage, newsites::DataFrames.DataFrame, sites::S
     end
 
     #assemblagejoin!(asm.site.sitestats, newsites, :sites, sites) #TODO this should instead be on the sitenames of the objects and adjusted below
-    nm = names(newsites)
+    nm = propertynames(newsites)
     rename!(newsites, sites => :sites)
     asm.site.sitestats = join(asm.site.sitestats, newsites, kind = :left, on = :sites, makeunique = makeunique)
     names!(newsites, nm)

--- a/src/Subsetting.jl
+++ b/src/Subsetting.jl
@@ -95,8 +95,8 @@ end
 # because I cannot define a new copy method for DataFrames
 function my_dataframe_copy(sdf::AbstractDataFrame)
     ret = DataFrame()
-    for n in names(sdf)
-        ret[n] = sdf[n]
+    for n in propertynames(sdf)
+        ret[!,n] = sdf[:,n]
     end
     ret
 end

--- a/test/Analysis_tests.jl
+++ b/test/Analysis_tests.jl
@@ -8,7 +8,7 @@ using Plots
     amphdat = CSV.read(joinpath(dirname(pathof(SpatialEcology)), "..", "data", "amph_Europe.csv"), DataFrame)
     amph = Assemblage(amphdat[!,4:end], amphdat[!,1:3], sitecolumns = false)
     addtraits!(amph, asquantiles(occupancy(amph), 4), :quantile)
-    gb = groupspecies(amph, :quantile)
+    gb = groupspecies(amph, :quantile) # error ?
     ps = [plot(g) for g in gb]
     p = ps[4];
 

--- a/test/Analysis_tests.jl
+++ b/test/Analysis_tests.jl
@@ -5,7 +5,7 @@ using Test
 using Plots
 
 @testset "Analysis" begin
-    amphdat = CSV.read(joinpath(dirname(pathof(SpatialEcology)), "..", "data", "amph_Europe.csv"))
+    amphdat = CSV.read(joinpath(dirname(pathof(SpatialEcology)), "..", "data", "amph_Europe.csv"), DataFrame)
     amph = Assemblage(amphdat[!,4:end], amphdat[!,1:3], sitecolumns = false)
     addtraits!(amph, asquantiles(occupancy(amph), 4), :quantile)
     gb = groupspecies(amph, :quantile)

--- a/test/Assemblage_tests.jl
+++ b/test/Assemblage_tests.jl
@@ -4,7 +4,7 @@ using SpatialEcology
 using Test
 
 @testset "Assemblage" begin
-    amphdat = CSV.read(joinpath(dirname(pathof(SpatialEcology)), "..", "data", "amph_Europe.csv"))
+    amphdat = CSV.read(joinpath(dirname(pathof(SpatialEcology)), "..", "data", "amph_Europe.csv"), DataFrame)
     amph = Assemblage(amphdat[!,4:end], amphdat[!,1:3], sitecolumns = false)
 
     @test typeof(amph) == Assemblage{Bool,SpatialEcology.Locations{SpatialEcology.GridData}}


### PR DESCRIPTION
The main impetus of this PR is to bump compat with DataFrames 0.21, which I thought would be quicker than finishing #37. I also changed julia compat to just "1.2" (because of semver this is identical to what you had before), fixed a deprecation warning from CSV.read in the tests, and added 1.5 to travis. This closes #54 as well.

There was also a failing test in `Analysis_tests.jl` related to the `addtraits!()` function, due to the fact that `names(df)` now returns `String`s ([see here](https://github.com/JuliaData/DataFrames.jl/commit/b1f675d89b63e5da4c6bdf0fb3f92bfab0c4d8c0)). I went looking and tried to fix other instances like this, but not sure I found them all. In any case, tests pass locally for these changes.