### PR TITLE
Fix Julia 1.11+ compatibility and several latent bugs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-DataFrames = "1.0, 1.1, 1.2"
+DataFrames = "1"
 DataFramesMeta = "0.5, 0.6, 0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15"
 Distances = "0.8, 0.9, 0.10"
 EcoBase = "0.1"

--- a/src/ComMatrix.jl
+++ b/src/ComMatrix.jl
@@ -4,7 +4,7 @@ macro forward_func(ex, fs)
 
     T = esc(T)
     fs = Meta.isexpr(fs, :tuple) ? map(esc, fs.args) : [esc(fs)]
-    :($([:($f(x::$T, args...) = (Base.@_inline_meta; $f(x.$field, args...)))
+    :($([:(@inline $f(x::$T, args...) = $f(x.$field, args...))
         for f in fs]...);
     nothing)
 end
@@ -53,7 +53,7 @@ const nsites = nplaces
 """
 nplaces(com::AbstractComMatrix) = size(com.occurrences, 2)
 nplaces(sd::SiteData) = size(coordinates(sd.site), 1)
-nplaces(sd::SELocations) = DataFrames.ncol(sd.sitestats)
+nplaces(sd::SELocations) = DataFrames.nrow(sd.sitestats)
 nplaces(gr::GridData) = size(gr.indices, 1)
 nplaces(pd::PointData) = size(pd.coords, 1)
 

--- a/src/Constructor_helperfunctions.jl
+++ b/src/Constructor_helperfunctions.jl
@@ -20,7 +20,7 @@ end
 
 function parsesingleDataFrame(occ::DataFrames.DataFrame)
     if isWorldmapData(occ)
-      println("Data format identified as Worldmap export file")
+      @info "Data format identified as Worldmap export file"
       coords = occ[!,4:5]
       coords[!,:sites] = createsitenames(coords)
       occ = DataFrame(site = coords[!,:sites], abu = ones(Int, DataFrames.nrow(occ)), species = occ[!,1])
@@ -56,7 +56,7 @@ function dataFrametoSparseMatrix(dat::DataFrames.DataFrame, ::Type{T}) where T<:
     is, js = Vector{Int}(), Vector{Int}()
 
     @inbounds for j in 1:DataFrames.ncol(dat)
-        col = dat[:,j]
+        col = dat[!,j]
         for i in 1:DataFrames.nrow(dat)
             if testbool(col[i])
                 push!(is, i)
@@ -72,7 +72,7 @@ function dataFrametoSparseMatrix(dat::DataFrames.DataFrame, ::Type{T}) where T<:
     is, js, vals = Vector{Int}(), Vector{Int}(), Vector{T}()
 
     @inbounds for j in 1:DataFrames.ncol(dat)
-        col = dat[:,j]
+        col = dat[!,j]
         for i in 1:DataFrames.nrow(dat)
             if !ismissing(col[i]) && col[i] != 0
                 push!(is, i)
@@ -104,16 +104,15 @@ end
 # these functions will be removed eventually
 maxrange(x) = diff([extrema(x)...])[1]
 
-# remember here - something wrong with the indices, make sure they are based from 1!
-
 function dropbyindex!(site::Locations{GridData}, indicestokeep)
   site.coords.indices = site.coords.indices[indicestokeep,:]
   site.sitestats = site.sitestats[indicestokeep,:]
-  site.coords.grid.xmin = xrange(site.coords.grid)[minimum(site.coords.indices[:,1])]
-  site.coords.grid.ymin = yrange(site.coords.grid)[minimum(site.coords.indices[:,2])]
-  site.coords.grid.xcells = maxrange(site.coords.indices[:,1]) + 1
-  site.coords.grid.ycells = maxrange(site.coords.indices[:,2]) + 1
-  site.coords.indices = site.coords.indices - minimum(site.coords.indices) + 1
+  newgrid = subsetgrid(site.coords.indices, site.coords.grid)
+  x_shift = Int.((xmin(newgrid) - xmin(site.coords.grid)) / xcellsize(site.coords.grid))
+  y_shift = Int.((ymin(newgrid) - ymin(site.coords.grid)) / ycellsize(site.coords.grid))
+  site.coords.indices[:,1] .-= x_shift
+  site.coords.indices[:,2] .-= y_shift
+  site.coords.grid = newgrid
 end
 
 function dropsites!(occ::ComMatrix, site::SELocations)

--- a/src/Constructors.jl
+++ b/src/Constructors.jl
@@ -71,7 +71,7 @@ end
 
 function ComMatrix(occ::DataFrames.DataFrame; sitecolumns = true)
     if DataFrames.ncol(occ) == 3 && eltypest(occ)[3] <: AbstractString
-        println("Data format identified as Phylocom")
+        @info "Data format identified as Phylocom"
         sites = unique(occ[!,1])
         species = unique(occ[!,3])
         js = indexin(occ[!,1], sites)
@@ -91,15 +91,15 @@ function ComMatrix(occ::DataFrames.DataFrame; sitecolumns = true)
 
     try
         occ = dataFrametoSparseMatrix(occ, Bool)
-        println("Matrix data assumed to be presence-absence")
+        @info "Matrix data assumed to be presence-absence"
     catch
         try
             occ = dataFrametoSparseMatrix(occ, Int) #TODO These lines mean that this code is not completely type stable.
-            println("Matrix data assumed to be abundances, minimum $(minimum(occ)), maximum $(maximum(occ))")
+            @info "Matrix data assumed to be abundances, minimum $(minimum(occ)), maximum $(maximum(occ))"
         catch
             occ = dataFrametoSparseMatrix(occ, Float64)
-            println("Matrix data assumed to be relative abundances, minimum $(minimum(occ)), maximum $(maximum(occ))")
-            (minimum(occ) < 0 || maximum(occ) > 1) && @info("Values don't fall in the 0,1 range")
+            @info "Matrix data assumed to be relative abundances, minimum $(minimum(occ)), maximum $(maximum(occ))"
+            (minimum(occ) < 0 || maximum(occ) > 1) && @info "Values don't fall in the 0,1 range"
         end
     end
 

--- a/src/GetandSetdata.jl
+++ b/src/GetandSetdata.jl
@@ -65,14 +65,11 @@ function addtraits!(asm::Assemblage, newtraits::DataFrames.DataFrame, species::S
         max(dif/left, dif/right) < tolerance && error("Aborting join, as fit was smaller than the tolerance of $tolerance . To perform the join decrease the tolerance value")
     end
 
-    nm = propertynames(newtraits)
-    rename!(newtraits, species => :name)
+    jointraits = rename(newtraits, species => :name)
     asm.occ.traits.__run_number = 1:nrow(asm.occ.traits)
-    asm.occ.traits = leftjoin(asm.occ.traits, newtraits, on = :name, makeunique = makeunique)
+    asm.occ.traits = leftjoin(asm.occ.traits, jointraits, on = :name, makeunique = makeunique)
     sort!(asm.occ.traits, :__run_number)
     select!(asm.occ.traits, Not(:__run_number))
-    rename!(newtraits, nm)
-    #assemblagejoin!(asm.occ.traits, newtraits, :name, species)
     nothing
 end
 
@@ -94,14 +91,11 @@ function addsitestats!(asm::Assemblage, newsites::DataFrames.DataFrame, sites::S
         max(dif/left, dif/right) < tolerance && error("Aborting join, as fit was smaller than the tolerance of $tolerance . To perform the join decrease the tolerance value")
     end
 
-    #assemblagejoin!(asm.site.sitestats, newsites, :sites, sites) #TODO this should instead be on the sitenames of the objects and adjusted below
-    nm = propertynames(newsites)
-    rename!(newsites, sites => :sites)
+    joinsites = rename(newsites, sites => :sites)
     asm.site.sitestats.__run_number = 1:nrow(asm.site.sitestats)
-    asm.site.sitestats = leftjoin(asm.site.sitestats, newsites, on = :sites, makeunique = makeunique)
+    asm.site.sitestats = leftjoin(asm.site.sitestats, joinsites, on = :sites, makeunique = makeunique)
     sort!(asm.site.sitestats, :__run_number)
     select!(asm.site.sitestats, Not(:__run_number))
-    rename!(newsites, nm)
     nothing
 end
 

--- a/src/Grouping.jl
+++ b/src/Grouping.jl
@@ -3,13 +3,13 @@
     groupsites(a::EcoBase.AbstractAssemblage, s::Symbol; kwargs...)
 """
 groupsites(a::EcoBase.AbstractAssemblage, s::Symbol; kwargs...) = groupsites(a, a[s]; kwargs...)
-groupsites(a::EcoBase.AbstractAssemblage, s::AbstractVector; kwargs...) = [view(a, sites = [(!ismissing(y) && y == x) for y in s]; kwargs...) for x in sort(unique(s))]
+groupsites(a::EcoBase.AbstractAssemblage, s::AbstractVector; kwargs...) = [view(a, sites = [(!ismissing(y) && y == x) for y in s]; kwargs...) for x in sort(collect(skipmissing(unique(s))))]
 
 """
     groupspecies(a::EcoBase.AbstractAssemblage, s::Symbol; kwargs...)
 """
 groupspecies(a::EcoBase.AbstractAssemblage, s::Symbol; kwargs...) = groupspecies(a, a[s]; kwargs...)
-groupspecies(a::EcoBase.AbstractAssemblage, s::AbstractVector; kwargs...) = [view(a, species = [(!ismissing(y) && y == x) for y in s]; kwargs...) for x in sort(unique(s))]
+groupspecies(a::EcoBase.AbstractAssemblage, s::AbstractVector; kwargs...) = [view(a, species = [(!ismissing(y) && y == x) for y in s]; kwargs...) for x in sort(collect(skipmissing(unique(s))))]
 const GroupedAssemblage = Vector{T} where T<:EcoBase.AbstractAssemblage
 
 function show(io::IO, com::GroupedAssemblage)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -86,5 +86,5 @@ _grid_from_factor(gd::SEGrid, factor; xmin = nothing, ymin = nothing) = _grid_fr
 _grid_from_factor(gd::GridTopology, factor; xmin = nothing, ymin = nothing) = GridTopology(_range_from_factor(extrema(gd.xs)..., first(factor); inmin = xmin), _range_from_factor(extrema(gd.ys)..., last(factor); inmin = ymin))
 
 _default_fun(::Type{Bool}) = Base.any
-_default_fun(::Type{Integer}) = Base.sum
+_default_fun(::Type{<:Integer}) = Base.sum
 _default_fun(::Any) = error("Default aggregation functions are only defined for Assemblage{Bool} (presence-absence) and Assemblage{Int}")

--- a/src/Sparse_matrixfunctions.jl
+++ b/src/Sparse_matrixfunctions.jl
@@ -1,32 +1,41 @@
 
 # Functions for sparse array view sums - from https://discourse.julialang.org/t/slow-arithmetic-on-views-of-sparse-matrices/3644
 
-rowsum(x::SubArray{T,2,P}) where {T,P<:SparseMatrixCSC} = (x.parent * sparse(x.indices[2],ones(Int,length(x.indices[2])), ones(Int,length(x.indices[2])), size(x.parent,2),1))[x.indices[1]]
+function rowsum(x::SubArray{T,2,P}) where {T,P<:SparseMatrixCSC}
+    pi = parentindices(x)
+    (x.parent * sparse(pi[2], ones(Int, length(pi[2])), ones(Int, length(pi[2])), size(x.parent, 2), 1))[pi[1]]
+end
+
 function rowsum(x::SparseMatrixCSC{Bool})
-    active = zeros(Int, x.m)
+    active = zeros(Int, size(x, 1))
+    rv = rowvals(x)
     @inbounds for i in 1:nnz(x)
-        active[x.rowval[i]] += 1
+        active[rv[i]] += 1
     end
     active
 end
 
-colsum(x::SparseMatrixCSC{Bool}) = diff(view(x.colptr, 1:x.n+1))
-colsum(x::SubArray{T,2,P}) where {T,P<:SparseMatrixCSC} = (sparse(ones(Int,length(x.indices[1])), x.indices[1], ones(Int,length(x.indices[1])),1,size(x.parent,1))*x.parent)[x.indices[2]]
+colsum(x::SparseMatrixCSC{Bool}) = diff(SparseArrays.getcolptr(x))
+
+function colsum(x::SubArray{T,2,P}) where {T,P<:SparseMatrixCSC}
+    pi = parentindices(x)
+    (sparse(ones(Int, length(pi[1])), pi[1], ones(Int, length(pi[1])), 1, size(x.parent, 1)) * x.parent)[pi[2]]
+end
 
 # Functions for finding nonzero rows and columns from Dan Getz, http://stackoverflow.com/questions/43968445/identify-which-rows-or-columns-have-values-in-sparse-matrix
 
 function nzrows(a::SparseMatrixCSC)
-    active = falses(a.m)
+    active = falses(size(a, 1))
+    rv = rowvals(a)
     @inbounds for i in 1:nnz(a)
-        active[a.rowval[i]] = true
+        active[rv[i]] = true
     end
     findall(active)
 end
 
 function nzcols(a::SparseMatrixCSC)
-    res=Vector{Int}()
-    foldl((x,y)->(if (x<a.colptr[y]) push!(res,y-1) end; a.colptr[y]),2:a.n+1, init=a.colptr[1])
-    res
+    cp = SparseArrays.getcolptr(a)
+    findall(i -> cp[i] < cp[i+1], 1:size(a, 2))
 end
 
 inrange(v,r) = searchsortedlast(v,last(r))>=searchsortedfirst(v,first(r))
@@ -44,36 +53,40 @@ end
 
 function nzcols(b::SubArray{T,2,P,Tuple{Vector{Int64},Vector{Int64}}} where {T,P<:SparseMatrixCSC}
   )
-    brows = sort(unique(b.indices[1]))
+    pi = parentindices(b)
+    brows = sort(unique(pi[1]))
     @inbounds return [k
-      for (k,i) in enumerate(b.indices[2])
-      if b.parent.colptr[i]<b.parent.colptr[i+1] &&
-        sortedintersecting(b.parent.rowval[nzrange(b.parent,i)], brows)]
+      for (k,i) in enumerate(pi[2])
+      if !isempty(nzrange(b.parent, i)) &&
+        sortedintersecting(rowvals(b.parent)[nzrange(b.parent,i)], brows)]
 end
 
 function nzcols(b::SubArray{T,2,P,M} where {T,P<:SparseMatrixCSC, M<:Tuple{AbstractUnitRange{Int64},AbstractUnitRange{Int64}}}
   )
-    @inbounds return collect(i+1-first(b.indices[2])
-      for i in b.indices[2]
-      if b.parent.colptr[i]<b.parent.colptr[i+1] &&
-        inrange(b.parent.rowval[nzrange(b.parent,i)], b.indices[1]))
+    pi = parentindices(b)
+    @inbounds return collect(i+1-first(pi[2])
+      for i in pi[2]
+      if !isempty(nzrange(b.parent, i)) &&
+        inrange(rowvals(b.parent)[nzrange(b.parent,i)], pi[1]))
 end
 
 function nzcols(b::SubArray{T,2,P,M} where {T,P<:SparseMatrixCSC, M<:Tuple{AbstractUnitRange{Int64},Vector{Int64}}}
   )
-  @inbounds return [k
-    for (k,i) in enumerate(b.indices[2])
-    if b.parent.colptr[i]<b.parent.colptr[i+1] &&
-        inrange(b.parent.rowval[nzrange(b.parent,i)], b.indices[1])]
+    pi = parentindices(b)
+    @inbounds return [k
+      for (k,i) in enumerate(pi[2])
+      if !isempty(nzrange(b.parent, i)) &&
+        inrange(rowvals(b.parent)[nzrange(b.parent,i)], pi[1])]
 end
 
 function nzcols(b::SubArray{T,2,P,M} where {T,P<:SparseMatrixCSC,M<:Tuple{Vector{Int64},AbstractUnitRange{Int64}}}
   )
-    brows = sort(unique(b.indices[1]))
-    @inbounds return collect(i+1-first(b.indices[2])
-      for i in b.indices[2]
-      if b.parent.colptr[i]<b.parent.colptr[i+1] &&
-        sortedintersecting(b.parent.rowval[nzrange(b.parent,i)], brows))
+    pi = parentindices(b)
+    brows = sort(unique(pi[1]))
+    @inbounds return collect(i+1-first(pi[2])
+      for i in pi[2]
+      if !isempty(nzrange(b.parent, i)) &&
+        sortedintersecting(rowvals(b.parent)[nzrange(b.parent,i)], brows))
 end
 
 function findin2(inds,v,w)
@@ -92,22 +105,25 @@ end
 
 function nzrows(b::SubArray{T,2,P,Tuple{Vector{Int64}, U}} where {T,P<:SparseMatrixCSC, U<:Union{M, Vector{Int}}} where {M <: AbstractUnitRange{Int64}}
   )
-    active = falses(length(b.indices[1]))
-    inds = sortperm(b.indices[1])
-    brows = (b.indices[1])[inds]
-    @inbounds for c in b.indices[2]
-      active[findin2(inds,brows,b.parent.rowval[nzrange(b.parent,c)])] .= true
+    pi = parentindices(b)
+    active = falses(length(pi[1]))
+    inds = sortperm(pi[1])
+    brows = (pi[1])[inds]
+    @inbounds for c in pi[2]
+      active[findin2(inds, brows, rowvals(b.parent)[nzrange(b.parent, c)])] .= true
     end
     return findall(active)
 end
 
 function nzrows(b::SubArray{T,2,P,Tuple{M, U}} where {T,P<:SparseMatrixCSC, U<:Union{M, Vector{Int}}} where M <: AbstractUnitRange{Int64}
   )
-    active = falses(length(b.indices[1]))
-    @inbounds for c in b.indices[2]
-        for r in nzrange(b.parent,c)
-            if b.parent.rowval[r] in b.indices[1]
-                active[b.parent.rowval[r]+1-first(b.indices[1])] = true
+    pi = parentindices(b)
+    rv = rowvals(b.parent)
+    active = falses(length(pi[1]))
+    @inbounds for c in pi[2]
+        for r in nzrange(b.parent, c)
+            if rv[r] in pi[1]
+                active[rv[r]+1-first(pi[1])] = true
             end
         end
     end
@@ -116,10 +132,12 @@ end
 
 _nnz(x::AbstractMatrix) = nnz(x)
 function _nnz(b::SubArray{T,2,P}) where {T,P<:SparseMatrixCSC}
+    pi = parentindices(b)
+    rv = rowvals(b.parent)
     ret = 0
-    @inbounds for c in b.indices[2]
-        for r in nzrange(b.parent,c)
-            if b.parent.rowval[r] in b.indices[1]
+    @inbounds for c in pi[2]
+        for r in nzrange(b.parent, c)
+            if rv[r] in pi[1]
                 ret += 1
             end
         end

--- a/src/Subsetting.jl
+++ b/src/Subsetting.jl
@@ -51,7 +51,8 @@ end
 
 view(pd::SEPoints, sites) = SubPointData(view(pd.coords, sites, :))
 view(gd::SEGrid, sites) = SubGridData(view(gd.indices, sites, :), gd.grid)
-view(lo::SELocations, sites) = SubLocations{SubGridData}(view(lo.coords, sites), view(lo.sitestats, sites, :))
+view(lo::SELocations{<:GridData}, sites) = SubLocations{SubGridData}(view(lo.coords, sites), view(lo.sitestats, sites, :))
+view(lo::SELocations{<:PointData}, sites) = SubLocations{SubPointData}(view(lo.coords, sites), view(lo.sitestats, sites, :))
 view(sp::SESpatialData, sites = 1:nsites(sp)) = SubSiteData(view(sp.site, sites))
 
  function view(asm::SEAssemblage{D}; species = 1:nspecies(asm), sites = 1:nsites(asm), dropsites = false, dropspecies = false, dropempty = false) where D
@@ -77,7 +78,7 @@ Assemblage(assm::SubAssemblage) = copy(assm)
 
 copy(asm::SEAssemblage) = Assemblage(copy(asm.site), copy(asm.occ))
 copy(sp::SESpatialData) = SiteData(copy(sp.site))
-copy(pd::SEPoints) = PointData(copy(pd.coords), copy(pd.sitestats))
+copy(pd::SEPoints) = PointData(copy(pd.coords))
 copy(pd::AbstractComMatrix) = ComMatrix(copy(pd.occurrences), copy(pd.speciesnames), copy(pd.sitenames))
 copy(occ::SEThings) = SpeciesData(copy(occ.commatrix), my_dataframe_copy(occ.traits))
 copy(lo::SELocations) = Locations(copy(lo.coords), my_dataframe_copy(lo.sitestats))


### PR DESCRIPTION
## Summary

- **Widen `DataFrames` compat** from `"1.0, 1.1, 1.2"` to `"1"` — the package was blocked from resolving against any DataFrames version newer than 1.2 (current is 1.8)
- **Remove `Base.@_inline_meta`** from the `@forward_func` macro — deprecated in Julia 1.8 and removed in 1.11; replaced with `@inline` on the generated method definitions
- **Replace internal `SparseMatrixCSC` field access** (`.m`, `.n`, `.colptr`, `.rowval`) with the public API (`size`, `SparseArrays.getcolptr`, `rowvals`) throughout `Sparse_matrixfunctions.jl`
- **Replace `SubArray` internal `.indices`** with `parentindices()` throughout `Sparse_matrixfunctions.jl`
- **Fix `nplaces(SELocations)`**: was returning `ncol` (column count) instead of `nrow` (site count)
- **Fix `copy(SEPoints)`**: was passing a non-existent `sitestats` argument to `PointData`'s constructor (would throw `FieldError` at runtime)
- **Fix `_default_fun(::Type{Integer})`**: abstract type dispatch never matched concrete `Int64`/`Int32`; changed to `::Type{<:Integer}`
- **Fix `dropbyindex!(Locations{GridData})`**: was writing to non-existent fields `.xmin`, `.xcells` etc. on `GridTopology` (which only has `.xs` and `.ys`); now rebuilds the topology correctly via `subsetgrid`
- **Fix `view(SELocations)`**: hardcoded `SubLocations{SubGridData}` even for `PointData`-backed locations; now dispatches on subtype
- **Fix `addtraits!` / `addsitestats!`**: were renaming the caller's `DataFrame` in-place (and back); replaced with non-mutating `rename()`
- **`println` → `@info`** in constructors, so output can be suppressed with standard logging
- **`dat[:,j]` → `dat[!,j]`** in `dataFrametoSparseMatrix` inner loop (avoid allocating a copy per column)
- **`sort(unique(s))` → `sort(collect(skipmissing(unique(s))))`** in `groupsites`/`groupspecies` to handle grouping vectors with `missing` values

## Test plan

- [ ] All 97 existing tests pass (`Pkg.test()`) — verified on Julia 1.13-rc1
- [ ] No new tests added (fixes are to existing logic paths)