### PR TITLE
Make doc preview cleanup tolerant of a missing preview

### DIFF
--- a/.github/workflows/Doc_preview_cleanup.yml
+++ b/.github/workflows/Doc_preview_cleanup.yml
@@ -4,25 +4,33 @@ on:
   pull_request:
     types: [closed]
 
+# Ensure that only one cleanup runs at a time, to avoid races on gh-pages
+concurrency:
+  group: doc-preview-cleanup
+  cancel-in-progress: false
+
 jobs:
   doc-preview-cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout gh-pages branch
         uses: actions/checkout@v4
         with:
           ref: gh-pages
 
-      - name: Delete preview and history
+      - name: Delete preview and history + push changes
         run: |
-            git config user.name "Documenter.jl"
-            git config user.email "documenter@juliadocs.github.io"
-            git rm -rf "previews/PR$PRNUM"
-            git commit -m "delete preview"
-            git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
+            if [ -d "previews/PR$PRNUM" ]; then
+                git config user.name "Documenter.jl"
+                git config user.email "documenter@juliadocs.github.io"
+                git rm -rf "previews/PR$PRNUM"
+                git commit -m "delete preview"
+                git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
+                git push --force origin gh-pages-new:gh-pages
+            else
+                echo "No previews/PR$PRNUM directory on gh-pages; nothing to clean up."
+            fi
         env:
             PRNUM: ${{ github.event.number }}
-
-      - name: Push changes
-        run: |
-            git push --force origin gh-pages-new:gh-pages


### PR DESCRIPTION
The **Doc Preview Cleanup** workflow failed on the close of PR #93 with:

```
fatal: pathspec 'previews/PR93' did not match any files
Error: Process completed with exit code 128.
```

PR #93's docs *build* succeeded, but no `previews/PR93` was ever deployed to `gh-pages` (every other open/recent PR has one). The cleanup step ran `git rm -rf "previews/PR$PRNUM"` unconditionally, so when there's nothing to delete it hard-fails.

This guards the delete+push behind an existence check (`if [ -d "previews/PR$PRNUM" ]`), making the job a clean no-op when there is no preview to remove — matching the current Documenter.jl recommended cleanup workflow. Also adds `concurrency` (avoids races on `gh-pages`) and an explicit `contents: write` permission.

Pure CI change; no package code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)