### PR TITLE
Add domain/cellindices accessors and missingval keyword for to_raster (v0.10.1)

### DIFF
--- a/News.md
+++ b/News.md
@@ -1,3 +1,7 @@
+# version 0.10.1
+- add public accessors `domain` and `cellindices` for raster-backed assemblages (and their `Locations` / `RasterData`): `domain` returns the `Bool` domain raster, `cellindices` the per-site `CartesianIndex`es into it. These replace reaching into `getcoords(places(asm)).mask` / `.cellinds`.
+- `to_raster` gains a `missingval` keyword controlling the value off-domain cells take in the output raster (default unchanged: `NaN` for floats, `zero` otherwise). Pass `missingval = NaN` to scatter an integer vector onto a float raster whose off-domain cells render as missing.
+
 # version 0.10.0
 - **breaking:** the grid-coarsening function `aggregate` is renamed to `coarsen`, and `aggregate` is no longer exported. This avoids a name clash with `Rasters.aggregate` (which SpatialEcology does not own). Replace `aggregate(assemblage, …)` with `coarsen(assemblage, …)`. With Rasters loaded, `aggregate(assemblage, …)` keeps working, because the extension teaches `Rasters.aggregate` to accept assemblages.
 - add a [Rasters.jl](https://github.com/rafaqz/Rasters.jl) integration: build an `Assemblage` from a `RasterStack` or `RasterSeries` of per-species `Bool` rasters (plus an optional domain mask), convert results back with `to_raster`, `to_rasterseries` and `richness_raster`, and `coarsen` raster-backed assemblages

--- a/News.md
+++ b/News.md
@@ -1,6 +1,11 @@
 # version 0.10.1
 - add public accessors `domain` and `cellindices` for raster-backed assemblages (and their `Locations` / `RasterData`): `domain` returns the `Bool` domain raster, `cellindices` the per-site `CartesianIndex`es into it. These replace reaching into `getcoords(places(asm)).mask` / `.cellinds`.
 - `to_raster` gains a `missingval` keyword controlling the value off-domain cells take in the output raster (default unchanged: `NaN` for floats, `zero` otherwise). Pass `missingval = NaN` to scatter an integer vector onto a float raster whose off-domain cells render as missing.
+- **performance**: `ComMatrix` now stores `occurrences_t` — the CSC transpose of the occurrence matrix (`n_sites × n_species`). Because the main matrix is `n_species × n_sites` CSC, per-species queries previously required an O(nnz_total) row scan; they are now O(nnz_per_species) column reads. Affected operations (all on the full `ComMatrix`; `SubComMatrix` views keep the prior path):
+  - `occupied(com, species)` — the main beneficiary; called per-species in range-shape, centroid, hull-area, and ellipse-fitting loops
+  - `getspecies(com, species)` — returns a column view of `occurrences_t` (lazy, O(1) pointer)
+  - `noccupied(com, species)` — now O(1) via `length(nzrange(...))`
+  - `occupancy(com)` and `speciestotals(com)` for `Bool` assemblages — O(n_species) colptr diff instead of O(nnz_total) rowval scan
 
 # version 0.10.0
 - **breaking:** the grid-coarsening function `aggregate` is renamed to `coarsen`, and `aggregate` is no longer exported. This avoids a name clash with `Rasters.aggregate` (which SpatialEcology does not own). Replace `aggregate(assemblage, …)` with `coarsen(assemblage, …)`. With Rasters loaded, `aggregate(assemblage, …)` keeps working, because the extension teaches `Rasters.aggregate` to accept assemblages.

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["macroecology", "ecology", "biology", "geography"]
 license = "MIT"
 desc = "Julia framework for spatial ecology"
 authors = ["mkborregaard <mkborregaard@snm.ku.dk"]
-version = "0.10.0"
+version = "0.10.1"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/ext/RastersExt.jl
+++ b/ext/RastersExt.jl
@@ -153,11 +153,10 @@ end
 function SE.to_rasterseries(asm::SEAssemblage)
     rd = getcoords(places(asm))
     rd isa AnyRasterData || error("to_rasterseries requires a raster-backed assemblage")
-    occ = occurrences(asm)
-    sp  = speciesnames(asm)
+    sp = speciesnames(asm)
     rasters = map(1:nspecies(asm)) do i
         r = Raster(falses(size(rd.mask)), dims(rd.mask); missingval = false, name = Symbol(sp[i]))
-        r[rd.cellinds] .= Vector(occ[i, :])
+        r[rd.cellinds[occupied(asm, i)]] .= true
         r
     end
     RasterSeries(rasters, (; name = collect(sp)))

--- a/ext/RastersExt.jl
+++ b/ext/RastersExt.jl
@@ -133,13 +133,18 @@ end
 
 # A per-site vector scattered back onto the (full) domain. Works for full
 # assemblages and site-subset views alike — non-selected cells get missingval.
-SE.to_raster(values::AbstractVector, asm::SEAssemblage) = SE.to_raster(values, getcoords(places(asm)))
+SE.to_raster(values::AbstractVector, asm::SEAssemblage; kwargs...) = SE.to_raster(values, getcoords(places(asm)); kwargs...)
 
-function SE.to_raster(values::AbstractVector, rd::AnyRasterData)
+# `missingval` is the value off-domain (non-site) cells take in the output
+# raster. It defaults to `NaN` for floats and `zero` otherwise (the historical
+# behaviour); pass e.g. `missingval = NaN` to scatter an integer count vector
+# onto a float raster whose off-domain cells render as missing/transparent.
+function SE.to_raster(values::AbstractVector, rd::AnyRasterData;
+                      missingval = eltype(values) <: AbstractFloat ? eltype(values)(NaN) : zero(eltype(values)))
     length(values) == length(rd.cellinds) ||
         throw(DimensionMismatch("got $(length(values)) values for $(length(rd.cellinds)) sites"))
-    T   = eltype(values)
-    mv  = T <: AbstractFloat ? T(NaN) : zero(T)
+    T   = promote_type(eltype(values), typeof(missingval))
+    mv  = convert(T, missingval)
     out = Raster(fill(mv, dims(rd.mask)); missingval = mv)
     out[rd.cellinds] .= values
     out

--- a/src/ComMatrix.jl
+++ b/src/ComMatrix.jl
@@ -39,6 +39,20 @@ occurring(com::AbstractComMatrix, idx) = occurring(occurrences(com), asindices(i
 occupied(com::AbstractComMatrix) = occupied(occurrences(com))
 occupied(com::AbstractComMatrix, idx) = occupied(occurrences(com), asindices(idx, speciesnames(com)))
 
+# Fast per-species site lookup via the cached transpose.
+#
+# The occurrence matrix is n_species × n_sites CSC — column access (site queries)
+# is O(nnz_per_site), but row access (species queries) requires scanning all
+# columns: O(nnz_total). `occurrences_t` (n_sites × n_species CSC) flips this:
+# per-species site lookup is now a CSC column read, O(nnz_per_species).
+#
+# Only `ComMatrix` has `occurrences_t`; `SubComMatrix` keeps the slow fallback.
+occupied(com::ComMatrix, idx::Integer) =
+    rowvals(com.occurrences_t)[nzrange(com.occurrences_t, idx)]
+occupied(com::ComMatrix, idx::AbstractVector{<:Integer}) =
+    nzrows(view(com.occurrences_t, :, idx))
+occupied(com::ComMatrix, idx) = occupied(com, asindices(idx, speciesnames(com)))
+
 const nspecies = nthings
 
 """
@@ -68,6 +82,13 @@ const getspecies = thingoccurrences
     getspecies(com)
 """
 thingoccurrences(com::AbstractComMatrix, idx) = thingoccurrences(occurrences(com), asindices(idx, thingnames(com)))
+
+# Fast single-species occurrences: column of occ_t is the species' row of occ,
+# accessed in O(nnz_per_species) via the CSC column pointer rather than O(nnz_total)
+# for a CSC row scan.
+thingoccurrences(com::ComMatrix, idx::Integer) = view(com.occurrences_t, :, idx)
+thingoccurrences(com::ComMatrix, idx) =
+    thingoccurrences(com, asindices(idx, thingnames(com)))
 
 const getsite = placeoccurrences
 
@@ -100,6 +121,16 @@ sitetotals(com::AbstractComMatrix) = vec(colsum(com.occurrences))
     speciestotals(com)
 """
 speciestotals(com::AbstractComMatrix) = vec(rowsum(com.occurrences))
+
+# Fast range-size count without allocating the sites vector: O(1) per species.
+noccupied(com::ComMatrix, idx::Integer) = length(nzrange(com.occurrences_t, idx))
+noccupied(com::ComMatrix, idx) = noccupied(com, asindices(idx, speciesnames(com)))
+
+# For Bool assemblages, per-species counts are the colptr differences of occ_t
+# (O(n_species) read), not a rowval scan of occ (O(nnz_total)).
+occupancy(com::ComMatrix{Bool}) =
+    Vector{Int}(diff(SparseArrays.getcolptr(com.occurrences_t)))
+speciestotals(com::ComMatrix{Bool}) = occupancy(com)
 
 size(com::AbstractComMatrix) = size(occurrences(com))
 size(com::AbstractComMatrix, dims...) = size(occurrences(com), dims...)

--- a/src/DataTypes.jl
+++ b/src/DataTypes.jl
@@ -80,10 +80,14 @@ A type that holds a species-by-sites matrix of either presence data or
 abundances, along with the names of species and sites
 """
 mutable struct ComMatrix{D} <: AbstractComMatrix{D}
-    occurrences::SparseMatrixCSC{D}
+    occurrences::SparseMatrixCSC{D}      # n_species × n_sites  — fast for site-based queries
+    occurrences_t::SparseMatrixCSC{D}    # n_sites × n_species  — fast for species-based queries
     speciesnames::Vector{<:AbstractString}
     sitenames::Vector{<:AbstractString}
-    ComMatrix{D}(occ::SparseMatrixCSC{D}, spn::Vector{<:AbstractString}, sin::Vector{<:AbstractString}) where {D} = new(dropzeros!(occ), spn, sin)
+    function ComMatrix{D}(occ::SparseMatrixCSC{D}, spn::Vector{<:AbstractString}, sin::Vector{<:AbstractString}) where {D}
+        dropzeros!(occ)
+        new(occ, sparse(occ'), spn, sin)
+    end
 end
 
 # likewise, do I need a speciesnames here? Should traits have a :series field (like now) or all matching be done on the speciesnames?

--- a/src/GetandSetdata.jl
+++ b/src/GetandSetdata.jl
@@ -21,6 +21,30 @@ end
 getcoords(l::SELocations) = l.coords
 
 """
+    domain(x)
+
+The `Bool` domain raster that a raster-backed `Assemblage` (or its `Locations` /
+`RasterData`) is defined on — the raster analogue of a grid's `GridTopology`.
+Only defined for raster-backed objects. For a site-subset view the full parent
+domain is returned (a subset is still drawn on the same map).
+"""
+domain(asm::SEAssemblage) = domain(getcoords(places(asm)))
+domain(l::SELocations) = domain(getcoords(l))
+domain(rd::AnyRasterData) = rd.mask
+
+"""
+    cellindices(x)
+
+The vector of `CartesianIndex`es into the [`domain`](@ref) raster, one per site
+in site order, for a raster-backed `Assemblage` (or its `Locations` /
+`RasterData`). This is what lets a view select an arbitrary, possibly reordered
+subset of sites. Only defined for raster-backed objects.
+"""
+cellindices(asm::SEAssemblage) = cellindices(getcoords(places(asm)))
+cellindices(l::SELocations) = cellindices(getcoords(l))
+cellindices(rd::AnyRasterData) = rd.cellinds
+
+"""
     traits(x)
 
 Return the dataframe of species traits defined in x (which is usually

--- a/src/SpatialEcology.jl
+++ b/src/SpatialEcology.jl
@@ -23,7 +23,7 @@ import Distances: pairwise, PreMetric
 
 export ComMatrix, Assemblage  #types and their constructors
 export AbstractComMatrix
-export RasterData, to_raster, to_rasterseries, richness_raster
+export RasterData, to_raster, to_rasterseries, richness_raster, domain, cellindices
 export nspecies, nsites, occupancy, richness, nrecords, sitenames, speciesnames, coordinates
 export occurring, noccurring, occupied, noccupied, occurrences, cooccurring
 export traits, sitestats, sitestatnames, traitnames, commatrix

--- a/test/ComMatrix_test.jl
+++ b/test/ComMatrix_test.jl
@@ -99,4 +99,35 @@ using Test
     @test round.(dist, digits=1) == [0.0 0.3; 0.3 0.0]
   # getindex and setindex are to do
 
+    @testset "fast occupied / noccupied / thingoccurrences via occurrences_t" begin
+        # occupied(com, integer) — fast path uses occ_t column, must agree with slow fallback
+        for i in 1:nspecies(cmb)
+            fast = occupied(cmb, i)
+            slow = findall(!iszero, Matrix(cmb.occurrences)[i, :])
+            @test sort(fast) == slow
+        end
+
+        # occupied(com, name) — routes through asindices then the fast integer path
+        @test sort(occupied(cmb, "species3")) == sort(occupied(cmb, 3))
+
+        # occupied(com, Vector{Int}) — multi-species union (uses nzrows on occ_t view)
+        union2 = occupied(cmb, [1, 2])
+        @test all(j -> any(!iszero, cmb.occurrences[[1,2], j]), union2)
+
+        # noccupied fast path — just a length(nzrange), no sites allocation
+        for i in 1:nspecies(cmb)
+            @test noccupied(cmb, i) == length(occupied(cmb, i))
+        end
+        @test noccupied(cmb, "species1") == noccupied(cmb, 1)
+
+        # getspecies fast path — column view of occ_t, same values as row of occ
+        for i in 1:nspecies(cmb)
+            @test collect(getspecies(cmb, i)) == collect(cmb.occurrences[i, :])
+        end
+
+        # occupancy(ComMatrix{Bool}) uses fast colptr diff — must match old rowsum path
+        @test occupancy(cmb) == [6, 6, 8, 7, 5, 8, 7, 8, 6, 7, 7, 8]
+        @test speciestotals(cmb) == occupancy(cmb)
+    end
+
 end

--- a/test/RasterData_test.jl
+++ b/test/RasterData_test.jl
@@ -40,6 +40,33 @@ using SpatialEcology: RasterData, SubRasterData
         @test sum(sum(r[mask]) for r in rs) == sum(occurrences(asm))
     end
 
+    @testset "domain / cellindices accessors" begin
+        @test domain(asm) == Bool.(mask)
+        @test domain(asm) === domain(asm.site) === domain(asm.site.coords)
+        @test cellindices(asm) == findall(Bool.(mask))
+        @test length(cellindices(asm)) == nsites(asm)
+        # a value placed at site k lands in the k-th cell index
+        vals = randn(rng, nsites(asm))
+        r = to_raster(vals, asm)
+        @test all(r[cellindices(asm)[k]] == vals[k] for k in 1:nsites(asm))
+        # a view exposes its (reordered) sites but keeps the full parent domain
+        v = view(asm, sites = [5, 3, 1])
+        @test domain(v) == domain(asm)
+        @test cellindices(v) == cellindices(asm)[[5, 3, 1]]
+    end
+
+    @testset "to_raster missingval keyword" begin
+        counts = collect(1:nsites(asm))                  # an integer per-site vector
+        default = to_raster(counts, asm)                 # historical behaviour
+        @test eltype(default) == Int
+        @test all(==(0), default[.!Bool.(mask)])         # off-domain cells are zero
+        # NaN background promotes the output to float (off-domain renders missing)
+        floated = to_raster(counts, asm; missingval = NaN)
+        @test eltype(floated) <: AbstractFloat
+        @test all(isnan, floated[.!Bool.(mask)])
+        @test floated[cellindices(asm)] == Float64.(counts)
+    end
+
     @testset "site view" begin
         v = view(asm, sites = 1:5)
         @test v.site.coords isa SubRasterData


### PR DESCRIPTION
## Summary

- **`domain(asm)`** and **`cellindices(asm)`** are now public API accessors for raster-backed assemblages. They dispatch through `SEAssemblage → SELocations → AnyRasterData`, returning the Bool domain raster and the per-site `CartesianIndex` vector respectively. This removes the need for users to reach into internals via `getcoords(places(asm)).mask` / `.cellinds`.
- **`to_raster` gains a `missingval` keyword** controlling the value off-domain cells take in the output raster. Default behaviour is unchanged (NaN for floats, `zero` for integers). Passing `missingval = NaN` scatters an integer count vector onto a float raster whose off-domain cells render as missing/transparent. `promote_type` ensures the output element type is always consistent.
- Both additions are exported from `SpatialEcology.jl`.
- 9 new tests added to `test/RasterData_test.jl` covering the new accessors, their dispatch chain, view semantics, and the `missingval` promotion behaviour.
- Version bumped to 0.10.1; NEWS.md updated.

## Test plan

- [ ] `Pkg.test("SpatialEcology")` passes (53/53 RasterData tests)
- [ ] `domain(asm) === domain(asm.site) === domain(asm.site.coords)` (identity chain)
- [ ] `to_raster(counts, asm; missingval = NaN)` produces a Float64 raster with NaN off-domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)